### PR TITLE
283361: Fix backlinks errors

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require File.dirname(__FILE__) + '/lib/wiki_links_hook_listener'
 
-Rails.configuration.to_prepare do
+Rails.application.config.after_initialize do
   unless WikiContent.included_modules.include?(WikiLinksWikiContentPatch)
     WikiContent.send(:include, WikiLinksWikiContentPatch)
   end


### PR DESCRIPTION
Fixes the following errors:
* `undefined method `links_to' for #<WikiPage>`
* `undefined method `links_from' for #<WikiPage>`
* `undefined method `parse_all_pages` for #<Wiki>`